### PR TITLE
Fix utf8 encoding because of korean error

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,10 @@
 server:
   port: 8080  # 8080번 포트로 애플리케이션 실행
+  servlet:
+    encoding:
+      charset: UTF-8  # 서블릿 인코딩 설정
+      force-request: true
+      force-response: true
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -9,6 +14,6 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create  # create: 정의된 엔티티 데이터베이스 추가, update: 변경점만 반영, create-drop: 데이터베이스 반영 후 애플리케이션 종료 시 삭제, validate: 동일 여부 확인, none: 아무것도 하지 않음
+      ddl-auto: none  # create: 정의된 엔티티 데이터베이스 추가, update: 변경점만 반영, create-drop: 데이터베이스 반영 후 애플리케이션 종료 시 삭제, validate: 동일 여부 확인, none: 아무것도 하지 않음
     open-in-view: false # View layer 에서 JPA 영속성 관련 세션 연결을 허용하지 않는다.
-    generate-ddl: true  # DDL 생성
+    generate-ddl: false  # DDL 생성


### PR DESCRIPTION
## 작업내역
- 브라우저에서 한글 깨지는 현상 해결
- 서블릿 response 인코딩 설정 `UTF-8` 적용
- 기타 변경
   - JPA auto generation off
